### PR TITLE
Switched MarkerPackReader to "Warn" when an XmlElement can not be read instead of reporting an "Error" which goes into Sentry.

### DIFF
--- a/Events Module/EventsModule.cs
+++ b/Events Module/EventsModule.cs
@@ -137,7 +137,7 @@ namespace Events_Module {
                     ShowToggleButton = true
                 };
 
-                if (meta.Texture.GetTexture() != null) {
+                if (meta.Texture.HasTexture) {
                     es2.Icon = meta.Texture;
                 }
 

--- a/Events Module/manifest.json
+++ b/Events Module/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Events and Metas Observer",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "namespace": "bh.general.events",
   "package": "Events Module.dll",
   "manifest_version": 1,

--- a/Markers and Paths Module/PackFormat/TacO/Readers/MarkerPackReader.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Readers/MarkerPackReader.cs
@@ -59,9 +59,9 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
                 packDocument.LoadXml(packSrc);
                 packLoaded = true;
             } catch (XmlException ex) {
-                Logger.Error(ex, "Could not load tacO overlay file {pathableResourceManager} from {xmlPackContentsType} due to an XML error.", pathableResourceManager, xmlPackContents);
+                Logger.Warn(ex, "Could not load tacO overlay file {pathableResourceManager} from {xmlPackContentsType} due to an XML error.", pathableResourceManager, xmlPackContents);
             } catch (Exception ex) {
-                Logger.Error(ex, "Could not load tacO overlay file {pathableResourceManager} from {xmlPackContentsType} due to an unexpected exception.", pathableResourceManager, xmlPackContents);
+                Logger.Warn(ex, "Could not load tacO overlay file {pathableResourceManager} from {xmlPackContentsType} due to an unexpected exception.", pathableResourceManager, xmlPackContents);
             }
 
             if (packLoaded) {

--- a/Musician Module/Controls/SheetButton.cs
+++ b/Musician Module/Controls/SheetButton.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Blish_HUD.Controls;
 using Musician_Module.Notation.Persistance;
 using Blish_HUD;
+using Blish_HUD.Input;
 
 namespace Musician_Module.Controls {
 

--- a/Musician Module/MusicianModule.cs
+++ b/Musician Module/MusicianModule.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Blish_HUD;
 using Blish_HUD.Controls;
+using Blish_HUD.Input;
 using Blish_HUD.Modules;
 using Blish_HUD.Settings;
 using Blish_HUD.Modules.Managers;

--- a/Musician Module/manifest.json
+++ b/Musician Module/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Musician",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "namespace": "bh.general.musician",
   "package": "Musician Module.dll",
   "manifest_version": 1,

--- a/Universal Search Module/Controls/SearchResultItem.cs
+++ b/Universal Search Module/Controls/SearchResultItem.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Blish_HUD;
 using Blish_HUD.Controls;
+using Blish_HUD.Input;
 using Gw2Sharp.WebApi.V2.Models;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;

--- a/Universal Search Module/manifest.json
+++ b/Universal Search Module/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Universal Search",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "namespace": "bh.general.universalsearch",
   "package": "Universal Search Module.dll",
   "manifest_version": 1,


### PR DESCRIPTION
Log entries are huge: https://sentry.do-ny3.svr.gw2blishhud.com/share/issue/bc891e2497b14203bacbd11d2fa4d804/

Plan is to have it only output the line the error occurred on in the log instead of the entire marker pack XML.

This will be easiest to implement when we switch to XmlReader in #2.

----

Updated namespaces to adjust for https://github.com/blish-hud/Blish-HUD/pull/44