### PR TITLE
WIP: Prototyped pathables to allow for faster parsing and reduced memory usage

### DIFF
--- a/Markers and Paths Module/Markers and Paths Module.csproj
+++ b/Markers and Paths Module/Markers and Paths Module.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Library\NanoXml\NanoXmlNode.cs" />
     <Compile Include="Library\NanoXml\NanoXmlParsingException.cs" />
     <Compile Include="MarkersAndPathsModule.cs" />
+    <Compile Include="PackFormat\PackManager.cs" />
     <Compile Include="PackFormat\TacO\Behavior\BasicTacOBehavior.cs" />
     <Compile Include="PackFormat\TacO\Builders\AttributeBuilder.cs" />
     <Compile Include="PackFormat\TacO\Builders\PathingCategoryBuilder.cs" />
@@ -57,8 +58,12 @@
     <Compile Include="PackFormat\TacO\Pathables\TacOMarkerPathable.cs" />
     <Compile Include="PackFormat\TacO\Pathables\TacOTrailPathable.cs" />
     <Compile Include="PackFormat\TacO\PathingCategory.cs" />
+    <Compile Include="PackFormat\TacO\Prototypes\PathableType.cs" />
+    <Compile Include="PackFormat\TacO\Prototypes\PrototypePathable.cs" />
+    <Compile Include="PackFormat\TacO\Prototypes\PrototypeTrailSection.cs" />
     <Compile Include="PackFormat\TacO\Readers\MarkerPackReader.cs" />
     <Compile Include="PackFormat\TacO\Readers\TrlReader.cs" />
+    <Compile Include="PackFormat\TacO\TacOManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Markers and Paths Module/MarkersAndPathsModule.cs
+++ b/Markers and Paths Module/MarkersAndPathsModule.cs
@@ -35,8 +35,6 @@ namespace Markers_and_Paths_Module {
 
         private string _markerDirectory;
 
-        private List<Control> _moduleControls;
-
         private EventHandler<EventArgs> _onNewMapLoaded;
 
         private Store _persistentStore;
@@ -57,8 +55,6 @@ namespace Markers_and_Paths_Module {
 
         protected override void Initialize() {
             _markerDirectory = DirectoriesManager.GetFullDirectoryPath("markers");
-
-            _moduleControls = new List<Control>();
             _persistentStore = GameService.Store.RegisterStore(this.Namespace);
 
             _mapIcon = new CornerIcon() {
@@ -100,9 +96,7 @@ namespace Markers_and_Paths_Module {
         }
 
         private void ClearMenu() {
-            foreach (var control in _mapIconMenu.Children) {
-                control.Dispose();
-            }
+            // TODO: Actually clear the menu
         }
 
         private void BuildMenu() {
@@ -170,13 +164,8 @@ namespace Markers_and_Paths_Module {
             GameService.Pathing.NewMapLoaded -= _onNewMapLoaded;
 
             // Dispose all controls
-            _moduleControls.ForEach(c => c.Dispose());
-            _moduleControls.Clear();
             _mapIcon.Dispose();
             _mapIconMenu.Dispose();
-
-            _mapIcon     = null;
-            _mapIconMenu = null;
 
             // Unload and dispose all loaded pathables
             UnloadAllPackManagers();

--- a/Markers and Paths Module/PackFormat/PackManager.cs
+++ b/Markers and Paths Module/PackFormat/PackManager.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Blish_HUD.Controls;
+using Blish_HUD.PersistentStore;
+
+namespace Markers_and_Paths_Module.PackFormat {
+    public abstract class PackManager {
+
+        private readonly Store _packPersistentStore;
+
+        protected Store PackPersistentStore => _packPersistentStore;
+
+        public abstract string PackTypeName { get; }
+
+        public abstract bool Loaded { get; }
+
+        protected PackManager(Store modulePersistentStore) {
+            _packPersistentStore = modulePersistentStore.GetSubstore($"PackManager-{this.PackTypeName}");
+        }
+
+        public abstract void LoadPacks(string directoryPath, IProgress<string> progressIndicator);
+
+        public abstract void BuildCategoryMenu(ContextMenuStrip rootCategoryMenu);
+
+        public abstract void FinalizeLoad();
+
+        public abstract void UpdateState();
+
+        public abstract void UnloadPacks();
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Builders/PoiBuilder.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Builders/PoiBuilder.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
-using Blish_HUD;
+﻿using Blish_HUD;
+using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
 using Blish_HUD.Pathing.Content;
 using NanoXml;
 
@@ -17,18 +13,22 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Builders {
         private const string ELEMENT_POITYPE_TRAIL = "trail";
         private const string ELEMENT_POITYPE_ROUTE = "route";
 
-        public static void UnpackPathable(NanoXmlNode pathableNode, PathableResourceManager pathableResourceManager, PathingCategory rootCategory) {
+        public static IPathable<Entity> UnpackPathable(NanoXmlNode pathableNode, PathableResourceManager pathableResourceManager, PathingCategory rootCategory) {
             switch (pathableNode.Name.ToLower()) {
                 case ELEMENT_POITYPE_POI:
                     var poiAttributes = AttributeBuilder.FromNanoXmlNode(pathableNode);
 
-                    var newPoiMarker = new Pathables.TacOMarkerPathable(poiAttributes, pathableResourceManager, rootCategory);
+                    if (poiAttributes.Contains("mapid")) {
 
-                    if (newPoiMarker.SuccessfullyLoaded) {
-                        MarkersAndPathsModule.ModuleInstance._currentReader.RegisterPathable(newPoiMarker);
-                    } else {
-                        Logger.Warn("Failed to load marker: {markerInfo}", poiAttributes);
                     }
+
+                    //var newPoiMarker = new Pathables.TacOMarkerPathable(poiAttributes, pathableResourceManager, rootCategory);
+
+                    //if (newPoiMarker.SuccessfullyLoaded) {
+                    //    return newPoiMarker;
+                    //} else {
+                    //    Logger.Warn("Failed to load marker: {markerInfo}", poiAttributes);
+                    //}
                     break;
 
                 case ELEMENT_POITYPE_TRAIL:
@@ -37,7 +37,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Builders {
                     var newPathTrail = new Pathables.TacOTrailPathable(trailAttributes, pathableResourceManager, rootCategory);
 
                     if (newPathTrail.SuccessfullyLoaded) {
-                        MarkersAndPathsModule.ModuleInstance._currentReader.RegisterPathable(newPathTrail);
+                        return newPathTrail;
                     } else {
                         Logger.Warn("Failed to load trail: {trailInfo}", trailAttributes);
                     }
@@ -48,9 +48,11 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Builders {
                     break;
 
                 default:
-                    Logger.Warn("Tried to pack {pathableNodeName} as a POI!", pathableNode.Name);
+                    Logger.Warn("Tried to load {pathableNodeName} as a POI!", pathableNode.Name);
                     break;
             }
+
+            return null;
         }
 
     }

--- a/Markers and Paths Module/PackFormat/TacO/Pathables/TacOTrailPathable.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Pathables/TacOTrailPathable.cs
@@ -73,9 +73,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Pathables {
             base.PrepareAttributes();
 
             // Type
-            RegisterAttribute("type",
-                              attribute => (!string.IsNullOrEmpty(this.Type = attribute.Value.Trim())),
-                              false);
+            RegisterAttribute("type", attribute => (!string.IsNullOrEmpty(this.Type = attribute.Value.Trim())));
 
             // [Required] TrailData
             RegisterAttribute("traildata",
@@ -142,7 +140,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Pathables {
 
                 sectionData.ForEach(t => {
                     this.MapId = t.MapId;
-                    this.ManagedEntity.AddSection(t.TrailPoints);
+                    //this.ManagedEntity.AddSection(t.TrailPoints);
                 });
             }
 

--- a/Markers and Paths Module/PackFormat/TacO/Pathables/TacOTrailPathable.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Pathables/TacOTrailPathable.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using Blish_HUD;
 using Blish_HUD.Pathing;
 using Blish_HUD.Pathing.Content;
+using Blish_HUD.Pathing.Entities;
 
 namespace Markers_and_Paths_Module.PackFormat.TacO.Pathables {
     public sealed class TacOTrailPathable : LoadedTrailPathable, ITacOPathable {
@@ -140,7 +141,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Pathables {
 
                 sectionData.ForEach(t => {
                     this.MapId = t.MapId;
-                    //this.ManagedEntity.AddSection(t.TrailPoints);
+                    this.ManagedEntity.AddSection(new ScrollingTrailSection(t.TrailPoints.ToList()));
                 });
             }
 

--- a/Markers and Paths Module/PackFormat/TacO/PathingCategory.cs
+++ b/Markers and Paths Module/PackFormat/TacO/PathingCategory.cs
@@ -37,7 +37,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO {
                 ? $"{this.Parent.Namespace}.{this.Name}"
                 : this.Name;
 
-        private List<IPathable> _pathables = new List<IPathable>();
+        private readonly List<IPathable> _pathables = new List<IPathable>();
 
         public ReadOnlyCollection<IPathable> Pathables => _pathables.AsReadOnly();
 
@@ -154,6 +154,10 @@ namespace Markers_and_Paths_Module.PackFormat.TacO {
 
         public void AddPathable(IPathable pathable) {
             _pathables.Add(pathable);
+        }
+
+        public void RemovePathable(IPathable pathable) {
+            _pathables.Remove(pathable);
         }
 
         public void SetAttributes(PathableAttributeCollection attributes) {

--- a/Markers and Paths Module/PackFormat/TacO/Prototypes/PathableType.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Prototypes/PathableType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Prototypes {
+    public enum PathableType {
+        Marker,
+        Trail
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Prototypes/PrototypePathable.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Prototypes/PrototypePathable.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Blish_HUD;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Content;
+using Blish_HUD.Pathing.Format;
+using Markers_and_Paths_Module.PackFormat.TacO.Pathables;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Prototypes {
+    public class PrototypePathable {
+
+        private static readonly Logger Logger = Logger.GetLogger(typeof(PrototypePathable));
+
+        private readonly PathableResourceManager     _resourceManager;
+        private readonly PathableType                _type;
+        private readonly int                         _mapId;
+        private readonly PathableAttributeCollection _attributes;
+
+        public PathableResourceManager     ResourceManager => _resourceManager;
+        public PathableType                Type            => _type;
+        public int                         MapId           => _mapId;
+        public PathableAttributeCollection Attributes      => _attributes;
+
+        public PrototypePathable(PathableResourceManager resourceManager, PathableType type, int mapId, PathableAttributeCollection attributes) {
+            _resourceManager = resourceManager;
+            _type            = type;
+            _mapId           = mapId;
+            _attributes      = attributes;
+        }
+
+        public IPathable LoadPathable() {
+            if (_type == PathableType.Marker) {
+                return LoadMarkerPathable();
+            } else {
+                return LoadTrailPathable();
+            }
+        }
+
+        private LoadedMarkerPathable LoadMarkerPathable() {
+            var newMarker = new TacOMarkerPathable(_attributes, _resourceManager, null);
+
+            if (newMarker.SuccessfullyLoaded) {
+                return newMarker;
+            } else {
+                Logger.Warn("Failed to load marker: {markerInfo}", _attributes);
+                return null;
+            }
+        }
+
+        private LoadedTrailPathable LoadTrailPathable() {
+            var newTrail = new TacOTrailPathable(_attributes, _resourceManager, null);
+
+            if (newTrail.SuccessfullyLoaded) {
+                return newTrail;
+            } else {
+                Logger.Warn("Failed to load trail: {trailInfo}", _attributes);
+                return null;
+            }
+        }
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Prototypes/PrototypePathable.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Prototypes/PrototypePathable.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Blish_HUD;
+using Blish_HUD.Entities;
 using Blish_HUD.Pathing;
 using Blish_HUD.Pathing.Content;
 using Blish_HUD.Pathing.Format;
@@ -31,16 +32,20 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Prototypes {
             _attributes      = attributes;
         }
 
-        public IPathable LoadPathable() {
-            if (_type == PathableType.Marker) {
-                return LoadMarkerPathable();
-            } else {
-                return LoadTrailPathable();
+        public IPathable<Entity> LoadPathable(PathingCategory rootCategory) {
+            switch (_type) {
+                case PathableType.Marker:
+                    return LoadMarkerPathable(rootCategory);
+                case PathableType.Trail:
+                    return LoadTrailPathable(rootCategory);
+                default:
+                    Logger.Warn("Unknown pathable type of {pathableType} could not be loaded!", _type);
+                    return null;
             }
         }
 
-        private LoadedMarkerPathable LoadMarkerPathable() {
-            var newMarker = new TacOMarkerPathable(_attributes, _resourceManager, null);
+        private LoadedMarkerPathable LoadMarkerPathable(PathingCategory rootCategory) {
+            var newMarker = new TacOMarkerPathable(_attributes, _resourceManager, rootCategory);
 
             if (newMarker.SuccessfullyLoaded) {
                 return newMarker;
@@ -50,8 +55,8 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Prototypes {
             }
         }
 
-        private LoadedTrailPathable LoadTrailPathable() {
-            var newTrail = new TacOTrailPathable(_attributes, _resourceManager, null);
+        private LoadedTrailPathable LoadTrailPathable(PathingCategory rootCategory) {
+            var newTrail = new TacOTrailPathable(_attributes, _resourceManager, rootCategory);
 
             if (newTrail.SuccessfullyLoaded) {
                 return newTrail;

--- a/Markers and Paths Module/PackFormat/TacO/Prototypes/PrototypeTrailSection.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Prototypes/PrototypeTrailSection.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Prototypes {
+    public struct PrototypeTrailSection {
+
+        private readonly int       _mapId;
+        private readonly Vector3[] _trailPoints;
+
+        public int MapId => _mapId;
+
+        public Vector3[] TrailPoints => _trailPoints;
+
+        public PrototypeTrailSection(int mapId, Vector3[] trailPoints) {
+            _mapId       = mapId;
+            _trailPoints = trailPoints;
+        }
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Readers/MarkerPackReader.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Readers/MarkerPackReader.cs
@@ -9,11 +9,12 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using Blish_HUD.Pathing.Content;
+using Markers_and_Paths_Module.PackFormat.TacO.Prototypes;
 using NanoXml;
 
 namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
 
-    public sealed class MarkerPackReader : IDisposable {
+    public sealed class MarkerPackReader {
 
         private static readonly Logger Logger = Logger.GetLogger(typeof(MarkerPackReader));
 
@@ -21,7 +22,9 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
 
         internal readonly SynchronizedCollection<IPathable<Entity>> Pathables = new SynchronizedCollection<IPathable<Entity>>();
 
-        public void RegisterPathable(IPathable<Entity> pathable) {
+        internal readonly SynchronizedCollection<Prototypes.PrototypePathable> PathablePrototypes = new SynchronizedCollection<PrototypePathable>();
+
+        private void RegisterPathable(IPathable<Entity> pathable) {
             if (pathable == null) return;
 
             this.Pathables.Add(pathable);
@@ -50,7 +53,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
                 xmlPackContents = xmlReader.ReadToEnd();
             }
 
-            NanoXml.NanoXmlDocument packDocument = null;
+            NanoXmlDocument packDocument = null;
 
             bool packLoaded = false;
 
@@ -85,21 +88,14 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
             var poisNodes = packDocument.RootNode.SelectNodes("pois");
 
             for (int pSet = 0; pSet < poisNodes.Length; pSet++) {
-                //ref var poisNode = ref poisNodes[pSet];
-                var poisNode = poisNodes[pSet];
+                ref var poisNode = ref poisNodes[pSet];
 
                 Logger.Info("Found {poiCount} POIs to load.", poisNode.SubNodes.Count());
 
                 for (int i = 0; i < poisNode.SubNodes.Count; i++) {
-                    Builders.PoiBuilder.UnpackPathable(poisNode.SubNodes[i], pathableResourceManager, rootCategory);
+                    this.RegisterPathable(Builders.PoiBuilder.UnpackPathable(poisNode.SubNodes[i], pathableResourceManager, rootCategory));
                 }
             }
-        }
-
-        /// <inheritdoc />
-        public void Dispose() {
-            this.Pathables.Clear();
-            this.Categories.Clear();
         }
 
     }

--- a/Markers and Paths Module/PackFormat/TacO/Readers/TrlReader.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Readers/TrlReader.cs
@@ -8,22 +8,11 @@ using System.Threading.Tasks;
 using Blish_HUD;
 
 namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
-    public struct TrlSection {
 
-        public int MapId;
-        public List<Vector3> TrailPoints;
+    public static class TrlReader {
 
-        public TrlSection(int mapId, List<Vector3> trailPoints) {
-            MapId = mapId;
-            TrailPoints = trailPoints.ToList();
-        }
-
-    }
-
-    public class TrlReader {
-
-        public static List<TrlSection> ReadStream(Stream trlStream) {
-            var trlSections = new List<TrlSection>();
+        public static List<Prototypes.PrototypeTrailSection> ReadStream(Stream trlStream) {
+            var trlSections = new List<Prototypes.PrototypeTrailSection>();
 
             // Ensure this stream can seek
             using (var srcStream = trlStream.CanSeek ? trlStream : trlStream.ReplaceWithMemoryStream()) {
@@ -45,7 +34,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
                         float y = trlReader.ReadSingle();
 
                         if (z == 0 && x == 0 && y == 0) {
-                            trlSections.Add(new TrlSection(mapId, trailPoints));
+                            trlSections.Add(new Prototypes.PrototypeTrailSection(mapId, trailPoints.ToArray()));
                             trailPoints.Clear();
                         } else {
                             trailPoints.Add(new Vector3(x, y, z));
@@ -54,7 +43,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
 
                     if (trailPoints.Any()) {
                         // Record the last trail segment
-                        trlSections.Add(new TrlSection(mapId, trailPoints));
+                        trlSections.Add(new Prototypes.PrototypeTrailSection(mapId, trailPoints.ToArray()));
                     }
                 }
             }
@@ -62,14 +51,14 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Readers {
             return trlSections;
         }
 
-        public static List<TrlSection> ReadBytes(byte[] rawTrlData) {
+        public static List<Prototypes.PrototypeTrailSection> ReadBytes(byte[] rawTrlData) {
             return ReadStream(new MemoryStream(rawTrlData));
         }
 
-        public static List<TrlSection> ReadFile(string trlPath) {
+        public static List<Prototypes.PrototypeTrailSection> ReadFile(string trlPath) {
             if (!File.Exists(trlPath)) {
                 Console.WriteLine("No trl file found at " + trlPath);
-                return new List<TrlSection>();
+                return new List<Prototypes.PrototypeTrailSection>();
             }
 
             return ReadStream(new FileStream(trlPath, FileMode.Open));

--- a/Markers and Paths Module/PackFormat/TacO/TacOManager.cs
+++ b/Markers and Paths Module/PackFormat/TacO/TacOManager.cs
@@ -89,11 +89,12 @@ namespace Markers_and_Paths_Module.PackFormat.TacO {
         public override void FinalizeLoad() {
             _allPathableResourceManagers.ForEach(GameService.Pathing.RegisterPathableResourceManager);
 
-            _currentReader.UpdatePathableStates();
+            _currentReader.UpdatePrototypePathableStates();
         }
 
         public override void UpdateState() {
-            _currentReader.UpdatePathableStates();
+            //_currentReader.UpdatePathableStates();
+            _currentReader.UpdatePrototypePathableStates();
         }
 
         public override void UnloadPacks() {
@@ -101,9 +102,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO {
             _allPathableResourceManagers.ForEach(GameService.Pathing.UnregisterPathableResourceManager);
 
             // Unregister all pathables
-            foreach (IPathable<Entity> pathable in _currentReader.Pathables) {
-                GameService.Pathing.UnregisterPathable(pathable);
-            }
+            _currentReader.UnloadPack();
 
             // Dispose all pathable resource managers
             _allPathableResourceManagers.ForEach(m => m.Dispose());

--- a/Markers and Paths Module/PackFormat/TacO/TacOManager.cs
+++ b/Markers and Paths Module/PackFormat/TacO/TacOManager.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Blish_HUD;
+using Blish_HUD.Content;
+using Blish_HUD.Controls;
+using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Content;
+using Blish_HUD.PersistentStore;
+using Markers_and_Paths_Module.PackFormat.TacO.Readers;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO {
+    public class TacOManager : PackManager {
+
+        private const string PACKTYPENAME = "TacO";
+
+        private bool                          _loaded = false;
+        private MarkerPackReader              _currentReader;
+        private List<PathableResourceManager> _allPathableResourceManagers;
+
+        public override string PackTypeName => PACKTYPENAME;
+        public override bool   Loaded       => _loaded;
+
+        public TacOManager(Store modulePersistentStore) : base(modulePersistentStore) { /* NOOP */ }
+
+        public override void LoadPacks(string directoryPath, IProgress<string> progressIndicator) {
+            _currentReader = new MarkerPackReader();
+
+            _allPathableResourceManagers = new List<PathableResourceManager>();
+
+            var dirDataReader      = new DirectoryReader(directoryPath);
+            var dirResourceManager = new PathableResourceManager(dirDataReader);
+            _allPathableResourceManagers.Add(dirResourceManager);
+            dirDataReader.LoadOnFileType((Stream fileStream, IDataReader dataReader) => {
+                _currentReader.ReadFromXmlPack(fileStream, dirResourceManager);
+            }, ".xml", progressIndicator);
+
+            // Load archive marker packs
+            var zipPackFiles = new List<string>();
+            zipPackFiles.AddRange(Directory.GetFiles(directoryPath, "*.zip",  SearchOption.AllDirectories));
+            zipPackFiles.AddRange(Directory.GetFiles(directoryPath, "*.taco", SearchOption.AllDirectories));
+
+            foreach (string packFile in zipPackFiles) {
+                // Potentially contains many packs within
+                var zipDataReader      = new ZipArchiveReader(packFile);
+                var zipResourceManager = new PathableResourceManager(zipDataReader);
+                _allPathableResourceManagers.Add(zipResourceManager);
+                zipDataReader.LoadOnFileType((Stream fileStream, IDataReader dataReader) => {
+                    _currentReader.ReadFromXmlPack(fileStream, zipResourceManager);
+                }, ".xml", progressIndicator);
+            }
+
+            _loaded = true;
+        }
+
+        private void AddCategoryToMenuStrip(ContextMenuStrip parentMenuStrip, PathingCategory newCategory) {
+            var newCategoryMenuItem = parentMenuStrip.AddMenuItem(newCategory.DisplayName);
+            
+            StoreValue<bool> categoryStoreState = this.PackPersistentStore.GetOrSetValue(newCategory.Namespace, true);
+            newCategory.Visible = categoryStoreState.Value;
+
+            newCategoryMenuItem.CanCheck = true;
+            newCategoryMenuItem.Checked  = newCategory.Visible;
+
+            newCategoryMenuItem.CheckedChanged += delegate (object sender, CheckChangedEvent e) {
+                newCategory.Visible      = e.Checked;
+                categoryStoreState.Value = e.Checked;
+            };
+
+            if (newCategory.Count > 0) {
+                var childMenuStrip = new ContextMenuStrip();
+
+                newCategoryMenuItem.Submenu = childMenuStrip;
+
+                foreach (var childCategory in newCategory) {
+                    AddCategoryToMenuStrip(childMenuStrip, childCategory);
+                }
+            }
+        }
+
+        public override void BuildCategoryMenu(ContextMenuStrip rootCategoryMenu) {
+            for (int i = 0; i < _currentReader.Categories.Count; i++) {
+                AddCategoryToMenuStrip(rootCategoryMenu, _currentReader.Categories[i]);
+            }
+        }
+
+        public override void FinalizeLoad() {
+            _allPathableResourceManagers.ForEach(GameService.Pathing.RegisterPathableResourceManager);
+
+            _currentReader.UpdatePathableStates();
+        }
+
+        public override void UpdateState() {
+            _currentReader.UpdatePathableStates();
+        }
+
+        public override void UnloadPacks() {
+            // Unregister all pathable resource managers
+            _allPathableResourceManagers.ForEach(GameService.Pathing.UnregisterPathableResourceManager);
+
+            // Unregister all pathables
+            foreach (IPathable<Entity> pathable in _currentReader.Pathables) {
+                GameService.Pathing.UnregisterPathable(pathable);
+            }
+
+            // Dispose all pathable resource managers
+            _allPathableResourceManagers.ForEach(m => m.Dispose());
+        }
+
+    }
+}

--- a/Markers and Paths Module/manifest.json
+++ b/Markers and Paths Module/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Markers & Paths",
-  "version": "0.1.2",
+  "version": "0.2.2",
   "namespace": "bh.general.markersandpaths",
   "package": "Markers and Paths Module.dll",
   "manifest_version": 1,


### PR DESCRIPTION
This PR introduces pathable prototypes that store the raw attribute data that was parsed from the pack files.  When a new map is loaded, all prototypes for that map are converted to true pathables and displayed.

Loading the following marker packs (totallying approx. 46,100 markers & trails):

- tw_ALL_IN_ONE.taco
- TacO ReActif EN External.taco
- Deroirs Tryhard Marker Pack.zip
- Heros-Taco-Pack-blish-compatability.zip

The initial parsing of the marker packs into prototypes takes a reported 2-3 seconds compared to the over 20 seconds reported prior to the changes.

These changes are not ready.  Current known issues:

- [ ] Pathing menu does not clear the menu items when markers are reloaded.
- [ ] Reloading markers is untested and likely does not properly dispose of unloaded markers.
- [ ] Needs to be profiled.
- [ ] Category toggle state is not maintained between map loads or launches of the module.
- and more.