### PR TITLE
Remove module zip before creating new one.

### DIFF
--- a/Compass Module/BuildScripts/PackageModule.ps1
+++ b/Compass Module/BuildScripts/PackageModule.ps1
@@ -12,6 +12,7 @@ Write-Output "$($modulesDest)"
 
 Write-Output "Building $($noModuleName).bhm..."
 
+Remove-Item -Path "$($project)obj\$($noModuleName).zip" -Force
 Compress-Archive -Path "$($project)$($output)*" -DestinationPath "$($project)obj\$($noModuleName).zip" -Update
 Copy-Item "$($project)obj\$($noModuleName).zip" "$($modulesDest)$($noModuleName).bhm" -Force
 

--- a/Discord Rich Presence Module/BuildScripts/PackageModule.ps1
+++ b/Discord Rich Presence Module/BuildScripts/PackageModule.ps1
@@ -12,6 +12,7 @@ Write-Output "$($modulesDest)"
 
 Write-Output "Building $($noModuleName).bhm..."
 
+Remove-Item -Path "$($project)obj\$($noModuleName).zip" -Force
 Compress-Archive -Path "$($project)$($output)*" -DestinationPath "$($project)obj\$($noModuleName).zip" -Update
 Copy-Item "$($project)obj\$($noModuleName).zip" "$($modulesDest)$($noModuleName).bhm" -Force
 

--- a/Events Module/BuildScripts/PackageModule.ps1
+++ b/Events Module/BuildScripts/PackageModule.ps1
@@ -12,6 +12,7 @@ Write-Output "$($modulesDest)"
 
 Write-Output "Building $($noModuleName).bhm..."
 
+Remove-Item -Path "$($project)obj\$($noModuleName).zip" -Force
 Compress-Archive -Path "$($project)$($output)*" -DestinationPath "$($project)obj\$($noModuleName).zip" -Update
 Copy-Item "$($project)obj\$($noModuleName).zip" "$($modulesDest)$($noModuleName).bhm" -Force
 

--- a/Loading Screen Hints Module/BuildScripts/PackageModule.ps1
+++ b/Loading Screen Hints Module/BuildScripts/PackageModule.ps1
@@ -12,6 +12,7 @@ Write-Output "$($modulesDest)"
 
 Write-Output "Building $($noModuleName).bhm..."
 
+Remove-Item -Path "$($project)obj\$($noModuleName).zip" -Force
 Compress-Archive -Path "$($project)$($output)*" -DestinationPath "$($project)obj\$($noModuleName).zip" -Update
 Copy-Item "$($project)obj\$($noModuleName).zip" "$($modulesDest)$($noModuleName).bhm" -Force
 

--- a/Markers and Paths Module/BuildScripts/PackageModule.ps1
+++ b/Markers and Paths Module/BuildScripts/PackageModule.ps1
@@ -12,6 +12,7 @@ Write-Output "$($modulesDest)"
 
 Write-Output "Building $($noModuleName).bhm..."
 
+Remove-Item -Path "$($project)obj\$($noModuleName).zip" -Force
 Compress-Archive -Path "$($project)$($output)*" -DestinationPath "$($project)obj\$($noModuleName).zip" -Update
 Copy-Item "$($project)obj\$($noModuleName).zip" "$($modulesDest)$($noModuleName).bhm" -Force
 

--- a/Musician Module/BuildScripts/PackageModule.ps1
+++ b/Musician Module/BuildScripts/PackageModule.ps1
@@ -12,6 +12,7 @@ Write-Output "$($modulesDest)"
 
 Write-Output "Building $($noModuleName).bhm..."
 
+Remove-Item -Path "$($project)obj\$($noModuleName).zip" -Force
 Compress-Archive -Path "$($project)$($output)*" -DestinationPath "$($project)obj\$($noModuleName).zip" -Update
 Copy-Item "$($project)obj\$($noModuleName).zip" "$($modulesDest)$($noModuleName).bhm" -Force
 

--- a/Universal Search Module/BuildScripts/PackageModule.ps1
+++ b/Universal Search Module/BuildScripts/PackageModule.ps1
@@ -12,6 +12,7 @@ Write-Output "$($modulesDest)"
 
 Write-Output "Building $($noModuleName).bhm..."
 
+Remove-Item -Path "$($project)obj\$($noModuleName).zip" -Force
 Compress-Archive -Path "$($project)$($output)*" -DestinationPath "$($project)obj\$($noModuleName).zip" -Update
 Copy-Item "$($project)obj\$($noModuleName).zip" "$($modulesDest)$($noModuleName).bhm" -Force
 


### PR DESCRIPTION
I found that the previous _PackageModule.ps1_ script did not remove the old zip file before creating the new one to deploy the final bhm.  When building with `Compress-Archive`, it does not overwrite the ZIP if it already exists.  Instead, it appends the items within the ZIP.

This was causing locally built modules to balloon in size as old items would not get removed.  This change resolves this by deleting any existing ZIP before building a new one.