### PR TITLE
Updated MAP and search modules for PR #99.

### DIFF
--- a/Markers and Paths Module/MarkersAndPathsModule.cs
+++ b/Markers and Paths Module/MarkersAndPathsModule.cs
@@ -64,10 +64,9 @@ namespace Markers_and_Paths_Module {
             _pathableToggleStates = GameService.Store.RegisterStore(this.Namespace);
 
             _mapIcon = new CornerIcon() {
-                BasicTooltipText = "Markers & Paths",
-                Icon             = ContentsManager.GetTexture("marker-pathing-icon.png"),
-                Priority         = "Markers & Paths".GetHashCode(),
-                Parent           = GameService.Graphics.SpriteScreen
+                IconName = "Markers & Paths",
+                Icon     = ContentsManager.GetTexture("marker-pathing-icon.png"),
+                Priority = "Markers & Paths".GetHashCode()
             };
 
             _onNewMapLoaded = delegate {

--- a/Universal Search Module/UniversalSearchModule.cs
+++ b/Universal Search Module/UniversalSearchModule.cs
@@ -71,10 +71,10 @@ namespace Universal_Search_Module {
 
         protected override async Task LoadAsync() {
             _searchIcon = new CornerIcon() {
-                Icon             = ContentsManager.GetTexture(@"textures\landmark-search.png"),
-                HoverIcon        = ContentsManager.GetTexture(@"textures\landmark-search-hover.png"),
-                BasicTooltipText = "Landmark Search",
-                Priority         = 5
+                IconName  = "Landmark Search",
+                Icon      = ContentsManager.GetTexture(@"textures\landmark-search.png"),
+                HoverIcon = ContentsManager.GetTexture(@"textures\landmark-search-hover.png"),
+                Priority  = 5
             };
 
             GameService.Debug.StartTimeFunc($"Loading all items");
@@ -99,12 +99,6 @@ namespace Universal_Search_Module {
             GameService.Debug.StopTimeFuncAndOutput($"Loading all items");
 
             _searchIcon.Click += delegate { _searchWindow.ToggleWindow(); };
-        }
-
-        protected override void OnModuleLoaded(EventArgs e) {
-            
-
-            base.OnModuleLoaded(e);
         }
 
         protected override void Update(GameTime gameTime) {


### PR DESCRIPTION
Blish HUD's PR#99 (https://github.com/blish-hud/Blish-HUD/pull/99) changed the requirements for showing text on `CornerIcon`s.  This implements this new method on both the Markers & Paths module as well as the Universal/Landmark Search module.

An unused overload was also removed to tidy it a bit.