### PR TITLE
Fix endless recreation loop when in-game. Clean-Up. Fixes #15

### DIFF
--- a/Loading Screen Hints Module/Controls/Hints/GamingTip.cs
+++ b/Loading Screen Hints Module/Controls/Hints/GamingTip.cs
@@ -56,7 +56,7 @@ namespace Loading_Screen_Hints_Module.Controls {
             "Across Tyria, one can find, aside from non-interactable cats, a number of cats and kittens that will accept certain food items, ingredients, or other specific items; some under specific circumstances.",
             "A red bar under your skills indicates that your target is too far away for your skill to reach.",
             "Mounts' health, stamina and engage skill damage are all separate and independent from the player's gear.",
-            "Mounts' have additional action abilities which are bindable in your keyboard options. These allow many maneuver and ways of traversing.",
+            "Mounts have additional action abilities which are bindable in your keyboard options. These allow many maneuver and ways of traversing.",
             "Moving the mouse pointer over each entry in the legend of your map will make any revealed point or scout pointing to not yet revealed renown hearts flash on the map, making them much easier to find.",
             "The LFG search bar allows to concatenate filters using whitespace as a separator. A minus (-) preceding a word will remove any party or squad listing containing the given word.",
             "You can also write \"consume\" or other parts of an item's type into the search box of your inventory or vault.",

--- a/Loading Screen Hints Module/Controls/Hints/GuessCharacter.cs
+++ b/Loading Screen Hints Module/Controls/Hints/GuessCharacter.cs
@@ -106,6 +106,7 @@ namespace Loading_Screen_Hints_Module.Controls {
             CharacterImage.SpriteBatchParameters.BlendState = BlendState.NonPremultiplied;
             Result = false;
         }
+
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             var center = new Point(this.Size.X / 2, this.Size.Y / 2);
             int centerLeft = center.X / 2;

--- a/Loading Screen Hints Module/Controls/Hints/Narration.cs
+++ b/Loading Screen Hints Module/Controls/Hints/Narration.cs
@@ -67,6 +67,7 @@ namespace Loading_Screen_Hints_Module.Controls {
         private string SelectedNarration;
         private string SelectedSource;
         private BitmapFont Font = GameService.Content.GetFont(ContentService.FontFace.Menomonia, ContentService.FontSize.Size18, ContentService.FontStyle.Regular);
+        private BitmapFont SourceFont = GameService.Content.GetFont(ContentService.FontFace.Menomonia, ContentService.FontSize.Size16, ContentService.FontStyle.Italic);
         public float ReadingTime { get; private set; }
         public Narration(int rnd) {
             var split = Narratives[rnd].Split('|');
@@ -83,12 +84,12 @@ namespace Loading_Screen_Hints_Module.Controls {
 
             string citation = DrawUtil.WrapText(this.Font, SelectedNarration, this.Width - LoadScreenPanel.RIGHT_PADDING);
             string sourceBind = "— ";
-            int srcBindWidth = (int)this.Font.MeasureString(sourceBind).Width;
-            int srcBindHeight = (int)this.Font.MeasureString(sourceBind).Height;
-            string source = DrawUtil.WrapText(this.Font, SelectedSource, centerRight / 2);
+            int srcBindWidth = (int)this.SourceFont.MeasureString(sourceBind).Width;
+            int srcBindHeight = (int)this.SourceFont.MeasureString(sourceBind).Height;
+            string source = DrawUtil.WrapText(this.SourceFont, SelectedSource, centerRight / 2);
 
-            int srcHeight = (int)this.Font.MeasureString(source).Height;
-            int srcWidth = (int)this.Font.MeasureString(source).Width;
+            int srcHeight = (int)this.SourceFont.MeasureString(source).Height;
+            int srcWidth = (int)this.SourceFont.MeasureString(source).Width;
             var srcCenter = new Point(center.X - (srcWidth / 2), center.Y - (srcHeight / 2));
 
             int textHeight = (int)this.Font.MeasureString(citation).Height + srcHeight;
@@ -98,10 +99,10 @@ namespace Loading_Screen_Hints_Module.Controls {
 
             int srcPaddingY = textCenter.Y + (textHeight / 2) + (this.Font.LineHeight);
             int srcBindPaddingX = centerRight - (srcWidth / 2) - srcBindWidth;
-            spriteBatch.DrawStringOnCtrl(this, sourceBind, this.Font, new Rectangle(srcBindPaddingX, srcPaddingY, srcBindWidth, srcBindHeight), Color.White, false, true, 2, left, top);
+            spriteBatch.DrawStringOnCtrl(this, sourceBind, this.SourceFont, new Rectangle(srcBindPaddingX, srcPaddingY, srcBindWidth, srcBindHeight), Color.White, false, true, 2, left, top);
 
             int srcPaddingX = centerRight - (srcWidth / 2);
-            spriteBatch.DrawStringOnCtrl(this, source, this.Font, new Rectangle(srcPaddingX, srcPaddingY, srcWidth, srcHeight), Color.White, false, true, 2, left, top);
+            spriteBatch.DrawStringOnCtrl(this, source, this.SourceFont, new Rectangle(srcPaddingX, srcPaddingY, srcWidth, srcHeight), Color.White, false, true, 2, left, top);
         }
     }
 }

--- a/Loading Screen Hints Module/Controls/LoadScreenPanel.cs
+++ b/Loading Screen Hints Module/Controls/LoadScreenPanel.cs
@@ -24,121 +24,63 @@ namespace Loading_Screen_Hints_Module.Controls {
 
         #endregion
 
-        private Random rand;
-        public Glide.Tween Fade;
-        private Control CurrentLoadScreenTip;
-        private HashSet<int> ShuffledHints;
-        private HashSet<int> SeenGamingTips;
-        private HashSet<int> SeenNarrations;
-        private HashSet<int> SeenGuessCharacters;
+        public Glide.Tween Fade { get; private set; }
+
+        public Control LoadScreenTip;
+
         public LoadScreenPanel() {
-            this.rand = new Random();
-            this.ShuffledHints = new HashSet<int>();
-            this.SeenGamingTips = new HashSet<int>();
-            this.SeenNarrations = new HashSet<int>();
-            this.SeenGuessCharacters = new HashSet<int>();
-
-            this.Size = new Point(600, 200); // set static bounds.
-
             UpdateLocation(null, null);
+
             Graphics.SpriteScreen.Resized += UpdateLocation;
+            Disposed += OnDisposed;
         }
 
         public void FadeOut() {
-            if (Fade != null) return;
 
             float duration = 2.0f;
-            if (this.CurrentLoadScreenTip != null) {
-                if (this.CurrentLoadScreenTip is GuessCharacter) {
-                    GuessCharacter selected = (GuessCharacter)this.CurrentLoadScreenTip;
+
+            if (LoadScreenTip != null) {
+
+                if (LoadScreenTip is GuessCharacter) {
+
+                    GuessCharacter selected = (GuessCharacter)LoadScreenTip;
                     selected.Result = true;
                     duration = duration + 3.0f;
-                } else if (this.CurrentLoadScreenTip is Narration) {
-                    Narration selected = (Narration)this.CurrentLoadScreenTip;
+
+                } else if (LoadScreenTip is Narration) {
+
+                    Narration selected = (Narration)LoadScreenTip;
                     duration = duration + selected.ReadingTime;
-                } else if (this.CurrentLoadScreenTip is GamingTip) {
-                    GamingTip selected = (GamingTip)this.CurrentLoadScreenTip;
+
+                } else if (LoadScreenTip is GamingTip) {
+
+                    GamingTip selected = (GamingTip)LoadScreenTip;
                     duration = duration + selected.ReadingTime;
+
                 }
             }
+
             Fade = Animation.Tweener.Tween(this, new { Opacity = 0.0f }, duration);
             Fade.OnComplete(() => {
-                this.Visible = false;
-                this.NextHint();
-                Fade.Cancel();
-                Fade = null;
+                Dispose();
             });
-
         }
-        public void NextHint() {
-            int total = 3;
-            int count = ShuffledHints.Count;
-            if (count >= total) { ShuffledHints.Clear(); count = 0; }
-            var range = Enumerable.Range(1, total).Where(i => !ShuffledHints.Contains(i));
-            int index = rand.Next(0, total - count - 1);
-            int hint = range.ElementAt(index);
 
-            ShuffledHints.Add(hint);
-
-            if (CurrentLoadScreenTip != null) {
-                if (CurrentLoadScreenTip is GuessCharacter) {
-                    GuessCharacter selected = (GuessCharacter)CurrentLoadScreenTip;
+        private void OnDisposed(object sender, EventArgs e)
+        {
+            if (LoadScreenTip != null)
+            {
+                if (LoadScreenTip is GuessCharacter)
+                {
+                    GuessCharacter selected = (GuessCharacter)LoadScreenTip;
                     selected.CharacterImage.Dispose();
                 }
-                CurrentLoadScreenTip.Dispose();
+                LoadScreenTip.Dispose();
             }
-
-            switch (hint) {
-                case 1:
-
-                    total = GamingTip.Tips.Count;
-                    count = SeenGamingTips.Count;
-                    if (count >= total) { SeenGamingTips.Clear(); count = 0; }
-                    range = Enumerable.Range(0, total).Where(i => !SeenGamingTips.Contains(i));
-                    index = rand.Next(0, total - count);
-                    hint = range.ElementAt(index);
-
-                    SeenGamingTips.Add(hint);
-                    CurrentLoadScreenTip = new GamingTip(hint) { Parent = this, Size = this.Size, Location = new Point(0, 0) };
-
-                    break;
-
-                case 2:
-
-                    total = Narration.Narratives.Count;
-                    count = SeenNarrations.Count;
-                    if (count >= total) { SeenNarrations.Clear(); count = 0; }
-                    range = Enumerable.Range(0, total).Where(i => !SeenNarrations.Contains(i));
-                    index = rand.Next(0, total - count);
-                    hint = range.ElementAt(index);
-
-                    SeenNarrations.Add(hint);
-                    CurrentLoadScreenTip = new Narration(hint) { Parent = this, Size = this.Size, Location = new Point(0, 0) };
-
-                    break;
-
-                case 3:
-
-                    total = GuessCharacter.Characters.Count;
-                    count = SeenGuessCharacters.Count;
-                    if (count >= total) { SeenGuessCharacters.Clear(); count = 0; }
-                    range = Enumerable.Range(0, total).Where(i => !SeenGuessCharacters.Contains(i));
-                    index = rand.Next(0, total - count);
-                    hint = range.ElementAt(index);
-
-                    SeenGuessCharacters.Add(hint);
-                    CurrentLoadScreenTip = new GuessCharacter(hint, this) { Location = new Point(0, 0) };
-
-                    break;
-
-                default:
-                    throw new NotSupportedException();
-            }
-            this.AddChild(CurrentLoadScreenTip);
         }
 
         private void UpdateLocation(object sender, EventArgs e) {
-            this.Location = new Point((Graphics.SpriteScreen.Width / 2 - this.Width / 2), (Graphics.SpriteScreen.Height / 2 - this.Height / 2) + 300);
+            this.Location = new Point((Graphics.SpriteScreen.Width / 2 - this.Width / 2), (Graphics.SpriteScreen.Height  / 2 - this.Height / 2) + 300);
         }
 
         public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {

--- a/Loading Screen Hints Module/Loading Screen Hints Module.csproj
+++ b/Loading Screen Hints Module/Loading Screen Hints Module.csproj
@@ -74,10 +74,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Controls\GamingTip.cs" />
-    <Compile Include="Controls\GuessCharacter.cs" />
+    <Compile Include="Controls\Hints\GamingTip.cs" />
+    <Compile Include="Controls\Hints\GuessCharacter.cs" />
     <Compile Include="Controls\LoadScreenPanel.cs" />
-    <Compile Include="Controls\Narration.cs" />
+    <Compile Include="Controls\Hints\Narration.cs" />
     <Compile Include="LoadingScreenHintsModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/Loading Screen Hints Module/LoadingScreenHintsModule.cs
+++ b/Loading Screen Hints Module/LoadingScreenHintsModule.cs
@@ -18,6 +18,8 @@ namespace Loading_Screen_Hints_Module {
     [Export(typeof(Module))]
     public class LoadingScreenHintsModule : Module {
 
+        private static readonly Logger Logger = Logger.GetLogger(typeof(LoadingScreenHintsModule));
+
         internal static LoadingScreenHintsModule ModuleInstance;
 
         // Service Managers
@@ -25,54 +27,126 @@ namespace Loading_Screen_Hints_Module {
         internal ContentsManager    ContentsManager    => this.ModuleParameters.ContentsManager;
         internal DirectoriesManager DirectoriesManager => this.ModuleParameters.DirectoriesManager;
         internal Gw2ApiManager      Gw2ApiManager      => this.ModuleParameters.Gw2ApiManager;
-        
+
         // Controls
         private LoadScreenPanel LoadScreenPanel;
+        private bool Created;
+
+        // Shuffle
+        private HashSet<int> ShuffledHints;
+        private HashSet<int> SeenGamingTips;
+        private HashSet<int> SeenNarrations;
+        private HashSet<int> SeenGuessCharacters;
+
+        private Random Randomize;
 
         [ImportingConstructor]
         public LoadingScreenHintsModule([Import("ModuleParameters")] ModuleParameters moduleParameters) : base(moduleParameters) {
             ModuleInstance = this;
         }
 
-        protected override void DefineSettings(SettingCollection settings) {
-            
+        protected override void DefineSettings(SettingCollection settings) { /** NOOP **/ }
+
+        protected override void Initialize() {
+            this.Randomize = new Random();
+            this.ShuffledHints = new HashSet<int>();
+            this.SeenGamingTips = new HashSet<int>();
+            this.SeenNarrations = new HashSet<int>();
+            this.SeenGuessCharacters = new HashSet<int>();
         }
 
-        protected override void Initialize() { /* NOOP */ }
-
-        protected override async Task LoadAsync() {
-            LoadScreenPanel = new LoadScreenPanel() {Opacity = 0f};
-        }
+        protected override async Task LoadAsync() { /** NOOP **/ }
 
         protected override void OnModuleLoaded(EventArgs e) {
-            LoadScreenPanel.Parent = GameService.Graphics.SpriteScreen;
-
             base.OnModuleLoaded(e);
         }
 
         protected override void Update(GameTime gameTime) {
-            if (!GameService.GameIntegration.IsInGame) {
-                if (LoadScreenPanel.Fade != null) {
-                    LoadScreenPanel.Fade.Cancel();
-                    LoadScreenPanel.Fade = null;
-                    LoadScreenPanel.NextHint();
-                }
 
-                LoadScreenPanel.Opacity = 1.0f;
-                LoadScreenPanel.Visible = true;
-
-                return;
+            if (!GameService.GameIntegration.IsInGame)
+            {
+                if (!Created) { NextHint(); Created = true; }
             }
-
-            if (LoadScreenPanel.Fade == null) { LoadScreenPanel.FadeOut(); }
+            else
+            {
+                if (LoadScreenPanel != null && LoadScreenPanel.Fade == null) { LoadScreenPanel.FadeOut(); }
+                Created = false;
+            }
         }
 
         protected override void Unload() {
             ModuleInstance = null;
 
-            LoadScreenPanel.Dispose();
+            if (LoadScreenPanel != null) { LoadScreenPanel.Dispose(); }
         }
 
-    }
+        public void NextHint()
+        {
+            if (LoadScreenPanel != null) { LoadScreenPanel.Dispose(); }
 
+            int total = 3;
+            int count = ShuffledHints.Count;
+            if (count >= total) { ShuffledHints.Clear(); count = 0; }
+            var range = Enumerable.Range(1, total).Where(i => !ShuffledHints.Contains(i));
+            int index = Randomize.Next(0, total - count - 1);
+            int hint = range.ElementAt(index);
+
+            ShuffledHints.Add(hint);
+
+            LoadScreenPanel = new LoadScreenPanel()
+            {
+                Parent = GameService.Graphics.SpriteScreen,
+                Size = new Point(600, 200),
+                Location = new Point((GameService.Graphics.SpriteScreen.Width / 2 - 300), (GameService.Graphics.SpriteScreen.Height / 2 - 100) + 300)
+            };
+
+            switch (hint)
+            {
+                case 1:
+
+                    total = GamingTip.Tips.Count;
+                    count = SeenGamingTips.Count;
+                    if (count >= total) { SeenGamingTips.Clear(); count = 0; }
+                    range = Enumerable.Range(0, total).Where(i => !SeenGamingTips.Contains(i));
+                    index = Randomize.Next(0, total - count);
+                    hint = range.ElementAt(index);
+
+                    SeenGamingTips.Add(hint);
+                    LoadScreenPanel.LoadScreenTip = new GamingTip(hint) { Parent = LoadScreenPanel, Size = LoadScreenPanel.Size, Location = new Point(0, 0) };
+
+                    break;
+
+                case 2:
+
+                    total = Narration.Narratives.Count;
+                    count = SeenNarrations.Count;
+                    if (count >= total) { SeenNarrations.Clear(); count = 0; }
+                    range = Enumerable.Range(0, total).Where(i => !SeenNarrations.Contains(i));
+                    index = Randomize.Next(0, total - count);
+                    hint = range.ElementAt(index);
+
+                    SeenNarrations.Add(hint);
+                    LoadScreenPanel.LoadScreenTip = new Narration(hint) { Parent = LoadScreenPanel, Size = LoadScreenPanel.Size, Location = new Point(0, 0) };
+
+                    break;
+
+                case 3:
+
+                    total = GuessCharacter.Characters.Count;
+                    count = SeenGuessCharacters.Count;
+                    if (count >= total) { SeenGuessCharacters.Clear(); count = 0; }
+                    range = Enumerable.Range(0, total).Where(i => !SeenGuessCharacters.Contains(i));
+                    index = Randomize.Next(0, total - count);
+                    hint = range.ElementAt(index);
+
+                    SeenGuessCharacters.Add(hint);
+                    LoadScreenPanel.LoadScreenTip = new GuessCharacter(hint, LoadScreenPanel) { Location = new Point(0, 0) };
+
+                    break;
+
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #15 

Also, clean-up.

@dlamkins Tried every BlendState but the character image's alpha is not affected by the fate out as it was before the render changes. Hopefully you can fix that on that end.
