### PR TITLE
Switched to using ToLowerInvariant() instead of ToLower() in many places.

### DIFF
--- a/Discord Rich Presence Module/DiscordRichPresenceModule.cs
+++ b/Discord Rich Presence Module/DiscordRichPresenceModule.cs
@@ -102,7 +102,7 @@ namespace Discord_Rich_Presence_Module {
                                                                    ? _mapOverrides[GameService.Player.Map.Id.ToString()]
                                                                    : DiscordUtil.GetDiscordSafeString(GameService.Player.Map.Name), 32),
                     LargeImageText = DiscordUtil.TruncateLength(GameService.Player.Map.Name,                                         128),
-                    SmallImageKey  = DiscordUtil.TruncateLength(((MapType) GameService.Player.MapType).ToString().ToLower(),         32),
+                    SmallImageKey  = DiscordUtil.TruncateLength(((MapType) GameService.Player.MapType).ToString().ToLowerInvariant(),         32),
                     SmallImageText = DiscordUtil.TruncateLength(((MapType) GameService.Player.MapType).ToString().Replace("_", " "), 128)
                 },
                 Timestamps = new Timestamps() {

--- a/Discord Rich Presence Module/DiscordUtil.cs
+++ b/Discord Rich Presence Module/DiscordUtil.cs
@@ -15,7 +15,7 @@ namespace Discord_Rich_Presence_Module {
         }
 
         public static string GetDiscordSafeString(string text) {
-            return Regex.Replace(text.Replace(":", "").Trim(), @"[^a-zA-Z]+", "_").ToLower();
+            return Regex.Replace(text.Replace(":", "").Trim(), @"[^a-zA-Z]+", "_").ToLowerInvariant();
         }
 
     }

--- a/Markers and Paths Module/Library/NanoXml/NanoXmlBase.cs
+++ b/Markers and Paths Module/Library/NanoXml/NanoXmlBase.cs
@@ -76,7 +76,7 @@ namespace NanoXml {
             // COMPAT: Tekkit packs have 0 before behavior in some places
             return str.Replace("*", "")
                       .TrimStart('0')
-                      .ToLower();
+                      .ToLowerInvariant();
         }
 
         protected static string CleanValue(string str) {

--- a/Markers and Paths Module/PackFormat/TacO/Builders/PoiBuilder.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Builders/PoiBuilder.cs
@@ -18,7 +18,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Builders {
         private const string ELEMENT_POITYPE_ROUTE = "route";
 
         public static void UnpackPathable(NanoXmlNode pathableNode, PathableResourceManager pathableResourceManager, PathingCategory rootCategory) {
-            switch (pathableNode.Name.ToLower()) {
+            switch (pathableNode.Name.ToLowerInvariant()) {
                 case ELEMENT_POITYPE_POI:
                     var poiAttributes = AttributeBuilder.FromNanoXmlNode(pathableNode);
 

--- a/Musician Module/MusicianModule.cs
+++ b/Musician Module/MusicianModule.cs
@@ -221,7 +221,7 @@ namespace Musician_Module
                 var melody = new SheetButton
                 {
                     Parent = melodyPanel,
-                    Icon = ContentsManager.GetTexture(@"instruments\" + sheet.Instrument.ToLower() + ".png"),
+                    Icon = ContentsManager.GetTexture(@"instruments\" + sheet.Instrument.ToLowerInvariant() + ".png"),
                     IconSize = DetailsIconSize.Small,
                     Artist = sheet.Artist,
                     Title = sheet.Title,

--- a/Musician Module/Notation/Persistance/RawMusicSheet.cs
+++ b/Musician Module/Notation/Persistance/RawMusicSheet.cs
@@ -7,10 +7,10 @@ namespace Musician_Module.Notation.Persistance
             Artist = artist;
             Title = title;
             User = user;
-            Instrument = instrument.ToLower();
+            Instrument = instrument.ToLowerInvariant();
             Tempo = tempo;
             Melody = melody;
-            Algorithm = algorithm.ToLower();
+            Algorithm = algorithm.ToLowerInvariant();
             Meter = meter;
         }
         public string Artist { get; private set; }


### PR DESCRIPTION
Switched to using ToLowerInvariant() instead of ToLower() when parsing or providing file paths. ToLower() used in search was kept since it should match the locale.

@TybaIt This touched the musician module somewhat, so figured you're probably best to review.  Just lowercasing with Invariant to ensure that when loading from file the user's locale culture won't break the file load (see https://github.com/blish-hud/Blish-HUD/issues/118 for reference).