### PR TITLE
Implements defaultToggle state on marker categories

### DIFF
--- a/Markers and Paths Module/MarkersAndPathsModule.cs
+++ b/Markers and Paths Module/MarkersAndPathsModule.cs
@@ -131,7 +131,7 @@ namespace Markers_and_Paths_Module {
 
             _moduleControls.Add(newCategoryMenuItem);
 
-            StoreValue<bool> categoryStoreState = _pathableToggleStates.GetOrSetValue(newCategory.Namespace, true);
+            StoreValue<bool> categoryStoreState = _pathableToggleStates.GetOrSetValue(newCategory.Namespace, newCategory.DefaultToggle);
             newCategory.Visible = categoryStoreState.Value;
 
             newCategoryMenuItem.CanCheck = !newCategory.IsSeparator;

--- a/Markers and Paths Module/PackFormat/TacO/Builders/PathingCategoryBuilder.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Builders/PathingCategoryBuilder.cs
@@ -15,9 +15,10 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Builders {
 
         private const string ELEMENT_CATEGORY = "markercategory";
 
-        private const string MARKERCATEGORY_NAME_ATTR        = "name";
-        private const string MARKERCATEGORY_DISPLAYNAME_ATTR = "displayname";
-        private const string MARKERCATEGORY_ISSEPARATOR_ATTR = "isseparator";
+        private const string MARKERCATEGORY_NAME_ATTR          = "name";
+        private const string MARKERCATEGORY_DISPLAYNAME_ATTR   = "displayname";
+        private const string MARKERCATEGORY_ISSEPARATOR_ATTR   = "isseparator";
+        private const string MARKERCATEGORY_DEFAULTTOGGLE_ATTR = "defaulttoggle";
 
         public static void UnpackCategory(NanoXmlNode categoryNode, PathingCategory categoryParent) {
             if (!string.Equals(categoryNode.Name, ELEMENT_CATEGORY, StringComparison.OrdinalIgnoreCase)) {
@@ -48,6 +49,7 @@ namespace Markers_and_Paths_Module.PackFormat.TacO.Builders {
 
             subjCategory.DisplayName = categoryNode.GetAttribute(MARKERCATEGORY_DISPLAYNAME_ATTR)?.Value;
             subjCategory.IsSeparator = categoryNode.GetAttribute(MARKERCATEGORY_ISSEPARATOR_ATTR)?.Value == "1";
+            subjCategory.DefaultToggle = categoryNode.GetAttribute(MARKERCATEGORY_DEFAULTTOGGLE_ATTR)?.Value != "0";
 
             subjCategory.SetAttributes(AttributeBuilder.FromNanoXmlNode(categoryNode));
 

--- a/Markers and Paths Module/PackFormat/TacO/PathingCategory.cs
+++ b/Markers and Paths Module/PackFormat/TacO/PathingCategory.cs
@@ -118,6 +118,18 @@ namespace Markers_and_Paths_Module.PackFormat.TacO {
             }
         }
 
+        private bool _defaultToggle = true;
+        public bool DefaultToggle
+        {
+            get => _defaultToggle;
+            set
+            {
+                if (_defaultToggle == value) return;
+
+                _defaultToggle = value;
+            }
+        }
+
         private readonly PathableAttributeCollection _attributes = new PathableAttributeCollection();
         public PathableAttributeCollection Attributes {
             get {


### PR DESCRIPTION
Categories are now disabled if a marker category sets `defaultToggle="0"` and the user did not check them previously.

Related issue: blish-hud/Blish-HUD/issues/86