### PR TITLE
Added extended filter behaviors.

### DIFF
--- a/Markers and Paths Module/MarkersAndPathsModule.cs
+++ b/Markers and Paths Module/MarkersAndPathsModule.cs
@@ -13,6 +13,7 @@ using Blish_HUD.Entities;
 using Blish_HUD.Modules;
 using Blish_HUD.Modules.Managers;
 using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Behaviors;
 using Blish_HUD.Pathing.Content;
 using Blish_HUD.PersistentStore;
 using Blish_HUD.Settings;
@@ -59,6 +60,8 @@ namespace Markers_and_Paths_Module {
 
         protected override void Initialize() {
             _markerDirectory = DirectoriesManager.GetFullDirectoryPath("markers");
+
+            PathingBehavior.AllAvailableBehaviors.AddRange(PathingBehaviorAttribute.GetTypes(System.Reflection.Assembly.GetExecutingAssembly()));
 
             _moduleControls = new List<Control>();
             _pathableToggleStates = GameService.Store.RegisterStore(this.Namespace);

--- a/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/FestivalFilter.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/FestivalFilter.cs
@@ -1,0 +1,35 @@
+﻿using Blish_HUD.Contexts;
+using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Behaviors;
+using System.Collections.Generic;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Behavior.Extended {
+
+    [PathingBehavior("festival")]
+    public class FestivalFilter<TPathable, TEntity> : FilterBehavior<TPathable, TEntity>
+        where TPathable : ManagedPathable<TEntity>
+        where TEntity : Entity {
+
+        private FestivalContext.Festival _festival;
+
+        public FestivalFilter(TPathable managedPathable) : base(managedPathable) { /* NOOP */ }
+
+        protected override void InitFilter() {
+            if (!_festival.IsActive()) {
+                this.Filtered = true;
+            }
+        }
+
+        public override void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
+            foreach (var attr in attributes) {
+                switch (attr.Name.ToLowerInvariant()) {
+                    case "festival":
+                        _festival = FestivalContext.Festival.FromName(attr.Value.Trim());
+                        break;
+                }
+            }
+        }
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/FilterBehavior.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/FilterBehavior.cs
@@ -1,0 +1,62 @@
+﻿using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Behaviors;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Behavior.Extended {
+    public abstract class FilterBehavior<TPathable, TEntity> : PathingBehavior<TPathable, TEntity>, ILoadableBehavior
+        where TPathable : ManagedPathable<TEntity>
+        where TEntity : Entity {
+
+        private bool _filtered = false;
+
+        public bool Filtered {
+            get => _filtered;
+            protected set {
+                _filtered = value;
+
+                UpdateFilter(value);
+            }
+        }
+
+        private List<PathingBehavior> _blockedBehaviors = new List<PathingBehavior>(0);
+
+        private void UpdateFilter(bool filter) {
+            if (filter) {
+                _blockedBehaviors = new List<PathingBehavior>(this.ManagedPathable.Behavior);
+                _blockedBehaviors.Remove(this);
+
+                this.ManagedPathable.Behavior.RemoveAll(b => _blockedBehaviors.Contains(b));
+
+                this.ManagedPathable.ManagedEntity.Visible = false;
+            } else {
+                this.ManagedPathable.ManagedEntity.Visible = true;
+
+                foreach (var behavior in _blockedBehaviors) {
+                    this.ManagedPathable.Behavior.Add(behavior);
+                }
+
+                _blockedBehaviors.Clear();
+            }
+        }
+
+        public FilterBehavior(TPathable managedPathable) : base(managedPathable) { /* NOOP */ }
+
+        private bool _firstUpdate = true;
+
+        public override void UpdateBehavior(GameTime gameTime) {
+            base.UpdateBehavior(gameTime);
+
+            if (_firstUpdate) {
+                _firstUpdate = false;
+                InitFilter();
+            }
+        }
+
+        protected abstract void InitFilter();
+
+        public abstract void LoadWithAttributes(IEnumerable<PathableAttribute> attributes);
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/MountFilter.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/MountFilter.cs
@@ -1,0 +1,44 @@
+﻿using Blish_HUD;
+using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Behaviors;
+using Gw2Sharp.Models;
+using System.Collections.Generic;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Behavior.Extended {
+
+    [PathingBehavior("mount")]
+    public class MountFilter<TPathable, TEntity> : FilterBehavior<TPathable, TEntity>
+        where TPathable : ManagedPathable<TEntity>
+        where TEntity : Entity {
+
+        private MountType? _mount;
+
+        public MountFilter(TPathable managedPathable) : base(managedPathable) { /* NOOP */ }
+
+        protected override void InitFilter() {
+            if (_mount.HasValue) {
+                HandleMountCheck();
+
+                GameService.Gw2Mumble.PlayerCharacter.CurrentMountChanged += delegate { HandleMountCheck(); };
+            }
+        }
+
+        private void HandleMountCheck() {
+            this.Filtered = _mount.Value != GameService.Gw2Mumble.PlayerCharacter.CurrentMount;
+        }
+
+        public override void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
+            foreach (var attr in attributes) {
+                switch (attr.Name.ToLowerInvariant()) {
+                    case "mount":
+                        if (InvariantUtil.TryParseInt(attr.Value, out int mount)) {
+                            _mount = (MountType)mount;
+                        }
+                        break;
+                }
+            }
+        }
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/ProfessionFilter.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/ProfessionFilter.cs
@@ -1,0 +1,44 @@
+﻿using Blish_HUD;
+using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Behaviors;
+using Gw2Sharp.Models;
+using System.Collections.Generic;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Behavior.Extended {
+
+    [PathingBehavior("profession")]
+    public class ProfessionFilter<TPathable, TEntity> : FilterBehavior<TPathable, TEntity>
+        where TPathable : ManagedPathable<TEntity>
+        where TEntity : Entity {
+
+        private ProfessionType? _profession;
+
+        public ProfessionFilter(TPathable managedPathable) : base(managedPathable) { /* NOOP */ }
+
+        protected override void InitFilter() {
+            if (_profession.HasValue) {
+                HandleProfessionCheck();
+
+                GameService.Gw2Mumble.PlayerCharacter.NameChanged += delegate { HandleProfessionCheck(); };
+            }
+        }
+
+        private void HandleProfessionCheck() {
+            this.Filtered = _profession.Value != GameService.Gw2Mumble.PlayerCharacter.Profession;
+        }
+
+        public override void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
+            foreach (var attr in attributes) {
+                switch (attr.Name.ToLowerInvariant()) {
+                    case "profession":
+                        if (InvariantUtil.TryParseInt(attr.Value, out int profession)) {
+                            _profession = (ProfessionType)profession;
+                        }
+                        break;
+                }
+            }
+        }
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/RaceFilter.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/RaceFilter.cs
@@ -1,0 +1,44 @@
+﻿using Blish_HUD;
+using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Behaviors;
+using Gw2Sharp.Models;
+using System.Collections.Generic;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Behavior.Extended {
+
+    [PathingBehavior("race")]
+    public class RaceFilter<TPathable, TEntity> : FilterBehavior<TPathable, TEntity>
+        where TPathable : ManagedPathable<TEntity>
+        where TEntity : Entity {
+
+        private RaceType? _race;
+
+        public RaceFilter(TPathable managedPathable) : base(managedPathable) { /* NOOP */ }
+
+        protected override void InitFilter() {
+            if (_race.HasValue) {
+                HandleRaceCheck();
+
+                GameService.Gw2Mumble.PlayerCharacter.NameChanged += delegate { HandleRaceCheck(); };
+            }
+        }
+
+        private void HandleRaceCheck() {
+            this.Filtered = _race.Value != GameService.Gw2Mumble.PlayerCharacter.Race;
+        }
+
+        public override void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
+            foreach (var attr in attributes) {
+                switch (attr.Name.ToLowerInvariant()) {
+                    case "race":
+                        if (InvariantUtil.TryParseInt(attr.Value, out int race)) {
+                            _race = (RaceType)race;
+                        }
+                        break;
+                }
+            }
+        }
+
+    }
+}

--- a/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/SpecializationFilter.cs
+++ b/Markers and Paths Module/PackFormat/TacO/Behavior/Extended/SpecializationFilter.cs
@@ -1,0 +1,41 @@
+﻿using Blish_HUD;
+using Blish_HUD.Entities;
+using Blish_HUD.Pathing;
+using Blish_HUD.Pathing.Behaviors;
+using System.Collections.Generic;
+
+namespace Markers_and_Paths_Module.PackFormat.TacO.Behavior.Extended {
+
+    [PathingBehavior("specialization")]
+    public class SpecializationFilter<TPathable, TEntity> : FilterBehavior<TPathable, TEntity>
+        where TPathable : ManagedPathable<TEntity>
+        where TEntity : Entity {
+
+        private int? _specialization;
+
+        public SpecializationFilter(TPathable managedPathable) : base(managedPathable) { /* NOOP */ }
+
+        protected override void InitFilter() {
+            if (_specialization.HasValue) {
+                HandleSpecializationCheck();
+
+                GameService.Gw2Mumble.PlayerCharacter.SpecializationChanged += delegate { HandleSpecializationCheck(); };
+            }
+        }
+
+        private void HandleSpecializationCheck() {
+            this.Filtered = _specialization.Value != GameService.Gw2Mumble.PlayerCharacter.Specialization;
+        }
+
+        public override void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
+            foreach (var attr in attributes) {
+                switch (attr.Name.ToLowerInvariant()) {
+                    case "specialization":
+                        if (InvariantUtil.TryParseInt(attr.Value, out int specialization)) {
+                            _specialization = specialization;
+                        }
+                        break;
+                }
+            }
+        }
+    }


### PR DESCRIPTION
Added support for new filter behaviors:

### festival="\<festivalname\>"

Will hide the pathable unless the specified festival is active.

The list of festival names that this checks against are located in the [FestivalContext](https://github.com/blish-hud/Blish-HUD/blob/51a49eb8f0e12b1c4af1b8305f6171c9de572ef8/Blish%20HUD/GameServices/Contexts/FestivalContext.cs#L86-L114).  Festivals currently supported are:
- halloween
- wintersday
- superadventurefestival
- lunarnewyear
- festivalofthefourwinds
- dragonbash

### mount="\<mountid\>"

Will hide the pathable unless the player is riding the specified mount.

The source list of mounts can be found in the [Gw2Sharp library under MountType](https://github.com/Archomeda/Gw2Sharp/blob/master/Gw2Sharp/Models/MountType.cs) which we reference for this information.  The list starts at 0 (None) and goes up as you go down the list (Jackal = 1, Griffon = 2, etc.).

If none (0) is specified, then the pathables will only show if the player is not using a mount.

### race="\<raceid\>"

Will hide the pathable unless the current character is a member of the specified race.

The source list of races can be found in the [Gw2Sharp library under RaceType](https://github.com/Archomeda/Gw2Sharp/blob/master/Gw2Sharp/Models/RaceType.cs) which we reference for this information.

### profession="\<professionid\>"

Will hide the pathable unless the current character is of the specified profession.

The source list of professions can be found in the [Gw2Sharp library under ProfessionType](https://github.com/Archomeda/Gw2Sharp/blob/master/Gw2Sharp/Models/ProfessionType.cs) which we reference for this information.

### specialization=\"<specialization\>"

Will hide the pathable unless the current character is of the specified specialization.

The API that we pull the specialization from is real-time, but has a few quirks to be mindful of.
- The ID we match against is the specialization ID of the third trait line - event if it is not elite.
- If the character has no third trait line specified (under level 71 or otherwise), then 0 is the ID we will detect as the active specialization.

The IDs will match what is found under the [/v2/specializations](https://api.guildwars2.com/v2/specializations) endpoint.  For instance, [40](https://api.guildwars2.com/v2/specializations/40) would match for Chronomancer.

You are not limited to just matching elite specializations as we'll report the ID of any specialization listed in the third trait row.