### PR TITLE
Update Tarir Event Timers

### DIFF
--- a/Events Module/ref/events.json
+++ b/Events Module/ref/events.json
@@ -690,7 +690,7 @@
   },
   {
     "name": "Trial by Fire",
-    "offset": "01:15Z",
+    "offset": "00:45Z",
     "repeat": "02:00",
     "difficulty": "",
     "category": "Meta Event",
@@ -704,7 +704,7 @@
   {
     "name": "Battle in Tarir",
     "colloquial": "Octovine",
-    "offset": "23:30Z",
+    "offset": "01:00Z",
     "repeat": "02:00",
     "difficulty": "",
     "category": "Meta Event",


### PR DESCRIPTION
Trial by Fire and Battle in Tarir were incorrect. Offsets are also now such that Pylons comes first (23:30), followed by Trial by Fire (00:45 -> 1h15 later), followed by the Octovine (01:00 -> 15 minutes later). Given a 20 minutes octovine + 10 minute reset, this now all sums to a 2 hour cycle.

I will be testing this locally later this evening, but I'm pretty sure this change is correct.