### PR TITLE
Fixes Blighting Tower's start offset

### DIFF
--- a/Events Module/ref/events.json
+++ b/Events Module/ref/events.json
@@ -603,7 +603,7 @@
   {
     "name": "Advancing on the Blighting Towers",
     "colloquial": "Dragon Stand",
-    "offset": "00:30Z",
+    "offset": "01:30Z",
     "repeat": "02:00",
     "difficulty": "",
     "category": "Meta Event",


### PR DESCRIPTION
We're currently off by one hour for some reason and the topic came up a few times but never got fixed:
- https://discord.com/channels/531175899588984842/534492012263636992/908127428524785724
- https://discord.com/channels/531175899588984842/534492012263636992/915235376791187477
- https://discord.com/channels/531175899588984842/534492173362528287/930212440996708484

Time has been confirmed again ingame and via [wiki](https://wiki.guildwars2.com/wiki/Dragon%27s_Stand).