### PR TITLE
Fetch all floors for Universal Search to get full list

### DIFF
--- a/Universal Search Module/UniversalSearchModule.cs
+++ b/Universal Search Module/UniversalSearchModule.cs
@@ -77,9 +77,11 @@ namespace Universal_Search_Module {
             // Continent 1 = Tyria
             // Continent 2 = Mists
             // Fetching a single floor will return all nested subresources as well, so fetch all floors
-            var floors = await Gw2ApiManager.Gw2ApiClient.V2.Continents[1].Floors.AllAsync();
+            var floors = await Gw2ApiManager.Gw2ApiClient.V2.Continents[1].Floors.IdsAsync();
 
-            foreach (var floor in floors) {
+            foreach (var floorId in floors) {
+                _searchIcon.LoadingMessage = $"Loading floor {floorId}...";
+                var floor = await Gw2ApiManager.Gw2ApiClient.V2.Continents[1].Floors[floorId].GetAsync();
                 foreach (var regionPair in floor.Regions) {
                     foreach (var mapPair in regionPair.Value.Maps) {
                         LoadedLandmarks.UnionWith(mapPair.Value.PointsOfInterest.Values.Where(landmark => landmark.Name != null));

--- a/Universal Search Module/UniversalSearchModule.cs
+++ b/Universal Search Module/UniversalSearchModule.cs
@@ -73,24 +73,24 @@ namespace Universal_Search_Module {
                 HoverIcon = ContentsManager.GetTexture(@"textures\landmark-search-hover.png"),
                 Priority  = 5
             };
+            
+            // Continent 1 = Tyria
+            // Continent 2 = Mists
+            // Fetching a single floor will return all nested subresources as well, so fetch all floors
+            var floors = await Gw2ApiManager.Gw2ApiClient.V2.Continents[1].Floors.AllAsync();
 
-            var regions = await Gw2ApiManager.Gw2ApiClient.V2.Continents[1].Floors[1].Regions.AllAsync();
-
-            foreach (var region in regions) {
-                _searchIcon.LoadingMessage = $"Loading {region.Name}...";
-                var maps = await Gw2ApiManager.Gw2ApiClient.V2.Continents[1].Floors[1].Regions[region.Id].Maps.AllAsync();
-
-                foreach (var map in maps) {
-                    _searchIcon.LoadingMessage = $"Loading {region.Name}: {map.Name}...";
-
-                    LoadedLandmarks.UnionWith(map.PointsOfInterest.Values.Where(landmark => landmark.Name != null));
-                    HeroPoints.UnionWith(map.SkillChallenges);
-                    MasteryPoints.UnionWith(map.MasteryPoints);
-                    HeroHearts.UnionWith(map.Tasks.Values);
-                    Areas.UnionWith(map.Sectors.Values);
+            foreach (var floor in floors) {
+                foreach (var regionPair in floor.Regions) {
+                    foreach (var mapPair in regionPair.Value.Maps) {
+                        LoadedLandmarks.UnionWith(mapPair.Value.PointsOfInterest.Values.Where(landmark => landmark.Name != null));
+                        HeroPoints.UnionWith(mapPair.Value.SkillChallenges);
+                        MasteryPoints.UnionWith(mapPair.Value.MasteryPoints);
+                        HeroHearts.UnionWith(mapPair.Value.Tasks.Values);
+                        Areas.UnionWith(mapPair.Value.Sectors.Values);
+                    }
                 }
             }
-
+            
             _searchIcon.LoadingMessage = null;
 
             _searchIcon.Click += delegate { _searchWindow.ToggleWindow(); };

--- a/Universal Search Module/UniversalSearchModule.cs
+++ b/Universal Search Module/UniversalSearchModule.cs
@@ -92,7 +92,7 @@ namespace Universal_Search_Module {
                     }
                 }
             }
-            
+
             _searchIcon.LoadingMessage = null;
 
             _searchIcon.Click += delegate { _searchWindow.ToggleWindow(); };


### PR DESCRIPTION
Previously, the module would call `Gw2ApiManager.Gw2ApiClient.V2.Continents[1].Floors[1]`, which would only get floor with ID 1, missing all of the other floors (floor IDs range from -57 to 68), which resulted in missing landmarks.

Instead, fetch all the floors, which will return all the nested subresources for that floor ([as per the API docs on the wiki](https://wiki.guildwars2.com/wiki/API:2/continents#:~:text=Floor%20and%20lower%20information)). To keep some form of loading indicator, fetch each floor individually (although the first few floors are the largest).

Example of [Heart of the Cauldron](https://wiki.guildwars2.com/wiki/Heart_of_the_Cauldron) which is at floor -38.
0.6.0:
![image](https://user-images.githubusercontent.com/818368/149844076-c54dbe84-4e45-4a0e-a285-e6d5334e77da.png)

This PR:
![image](https://user-images.githubusercontent.com/818368/149843998-ccdac067-57bb-49b1-991b-dc18236da9f7.png)

