### PR TITLE
Update discord rpc

### DIFF
--- a/Discord Rich Presence Module/Discord Rich Presence Module.csproj
+++ b/Discord Rich Presence Module/Discord Rich Presence Module.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -41,6 +43,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -50,6 +53,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DiscordRichPresenceModule.cs" />
@@ -60,6 +64,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="_Extensions\MapExtensions.cs" />
+    <Compile Include="_Extensions\StringExtensions.cs" />
+    <Compile Include="_Utils\TaskUtil.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">
@@ -94,6 +101,14 @@
     </Reference>
     <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
+    <Reference Include="Flurl, Version=2.8.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Flurl.2.8.2\lib\net40\Flurl.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Flurl.Http, Version=2.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Flurl.Http.2.4.2\lib\net46\Flurl.Http.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Gw2Sharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Gw2Sharp.1.0.0\lib\netstandard2.0\Gw2Sharp.dll</HintPath>
@@ -177,6 +192,7 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>

--- a/Discord Rich Presence Module/Discord Rich Presence Module.csproj.DotSettings
+++ b/Discord Rich Presence Module/Discord Rich Presence Module.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=_005Fextensions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=_005Futils/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Discord Rich Presence Module/_Extensions/MapExtensions.cs
+++ b/Discord Rich Presence Module/_Extensions/MapExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Gw2Sharp.WebApi.V2.Models;
+
+namespace Discord_Rich_Presence_Module
+{
+    public static class MapExtensions
+    {
+        /// <summary>
+        /// Gets a hash of the map's continent rectangle which can be used to identify copies of the same map.
+        /// </summary>
+        /// <param name="map">The map to get the hash of.</param>
+        /// <returns>
+        /// The first 8 characters of the SHA1 hash of the following string<br/>
+        /// <c>SHA1(&lt;continent_id&gt;&lt;continent_rect[0][0]&gt;&lt;continent_rect[0][1]&gt;&lt;continent_rect[1][0]&gt;&lt;continent_rect[1][1]&gt;)</c>
+        /// </returns>
+        public static string GetHash(this Map map)
+        {
+            var rpcHash = $"{map.ContinentId}{map.ContinentRect.TopLeft.X}{map.ContinentRect.TopLeft.Y}{map.ContinentRect.BottomRight.X}{map.ContinentRect.BottomRight.Y}";
+            return rpcHash.ToSHA1Hash().Substring(0, 8);
+        }
+    }
+}

--- a/Discord Rich Presence Module/_Extensions/StringExtensions.cs
+++ b/Discord Rich Presence Module/_Extensions/StringExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Discord_Rich_Presence_Module
+{
+    internal static class StringExtensions
+    {
+        public static string ToSHA1Hash(this string input, bool lowerCase = true)
+        {
+            using var sha1 = new SHA1Managed();
+            var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(input));
+            return string.Concat(hash.Select(b => b.ToString(lowerCase ? "x2" : "X2")));
+        }
+    }
+}

--- a/Discord Rich Presence Module/_Utils/TaskUtil.cs
+++ b/Discord Rich Presence Module/_Utils/TaskUtil.cs
@@ -1,0 +1,49 @@
+﻿using Flurl.Http;
+using Newtonsoft.Json;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Discord_Rich_Presence_Module
+{
+    public class TaskUtil
+    {
+        public static bool TryParseJson<T>(string json, out T result)
+        {
+            bool success = true;
+            var settings = new JsonSerializerSettings
+            {
+                Error = (_, args) => { success = false; args.ErrorContext.Handled = true; },
+                MissingMemberHandling = MissingMemberHandling.Error
+            };
+            result = JsonConvert.DeserializeObject<T>(json, settings);
+            return success;
+        }
+
+        public static async Task<(bool, T)> GetJsonResponse<T>(string request, int timeOutSeconds = 10)
+        {
+            try
+            {
+                var rawJson = await request.AllowHttpStatus(HttpStatusCode.NotFound).AllowHttpStatus("200").WithTimeout(timeOutSeconds).GetStringAsync();
+                return (TryParseJson<T>(rawJson, out var result), result);
+            }
+            catch (FlurlHttpTimeoutException ex)
+            {
+                DiscordRichPresenceModule.Logger.Warn(ex, $"Request '{request}' timed out.");
+            }
+            catch (FlurlHttpException ex)
+            {
+                DiscordRichPresenceModule.Logger.Warn(ex, $"Request '{request}' was not successful.");
+            }
+            catch (JsonReaderException ex)
+            {
+                DiscordRichPresenceModule.Logger.Warn(ex, $"Failed to deserialize requested content from \"{request}\"\n{ex.StackTrace}");
+            }
+            catch (Exception ex)
+            {
+                DiscordRichPresenceModule.Logger.Error(ex, $"Unexpected error while requesting '{request}'.");
+            }
+            return (false, default);
+        }
+    }
+}

--- a/Discord Rich Presence Module/packages.config
+++ b/Discord Rich Presence Module/packages.config
@@ -4,6 +4,8 @@
   <package id="BlishHUD" version="0.7.0" targetFramework="net472" />
   <package id="CSCore" version="1.2.1.2" targetFramework="net472" />
   <package id="DiscordRichPresence" version="1.0.175" targetFramework="net472" />
+  <package id="Flurl" version="2.8.2" targetFramework="net472" />
+  <package id="Flurl.Http" version="2.4.2" targetFramework="net472" />
   <package id="Gw2Sharp" version="1.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="MonoGame.Extended" version="3.7.0" targetFramework="net472" />


### PR DESCRIPTION
Requires the images from https://github.com/OpNop/GW2-RPC-Resources to be added to the Discord App.

Question: Backward compatible? Cache the maps json? Update maps json when mumble buildId changes?