### PR TITLE
Feat/0.11.8 support

### DIFF
--- a/Compass Module/CompassModule.cs
+++ b/Compass Module/CompassModule.cs
@@ -21,6 +21,7 @@ namespace Compass_Module {
         private SettingEntry<float> _settingCompassSize;
         private SettingEntry<float> _settingCompassRadius;
         private SettingEntry<float> _settingVerticalOffset;
+        private SettingEntry<bool>  _settingFadeForwardDirection;
 
         private CompassBillboard _northBb;
         private CompassBillboard _eastBb;
@@ -35,9 +36,10 @@ namespace Compass_Module {
         private const float VERTICALOFFSET_MIDDLE = 2.5f;
 
         protected override void DefineSettings(SettingCollection settings) {
-            _settingCompassSize    = settings.DefineSetting("CompassSize",    0.5f, "Compass Size",    "Size of the compass elements.");
-            _settingCompassRadius  = settings.DefineSetting("CompassRadius",  0f,   "Compass Radius",  "Radius of the compass.");
-            _settingVerticalOffset = settings.DefineSetting("VerticalOffset", VERTICALOFFSET_MIDDLE,   "Vertical Offset", "How high to offset the compass off the ground.");
+            _settingCompassSize          = settings.DefineSetting("CompassSize",          0.5f,                  () => "Compass Size",           () => "Size of the compass elements.");
+            _settingCompassRadius        = settings.DefineSetting("CompassRadius",        0f,                    () => "Compass Radius",         () => "Radius of the compass.");
+            _settingVerticalOffset       = settings.DefineSetting("VerticalOffset",       VERTICALOFFSET_MIDDLE, () => "Vertical Offset",        () => "How high to offset the compass off the ground.");
+            _settingFadeForwardDirection = settings.DefineSetting("FadeForwardDirection", true,                  () => "Fade Forward Direction", () => "If enabled, the direction in front of the character is faded out.");
 
             _settingCompassSize.SetRange(0.1f, 2f);
             _settingCompassRadius.SetRange(0f, 4f);
@@ -83,10 +85,17 @@ namespace Compass_Module {
         }
 
         private void UpdateBillboardOpacity() {
-            _northBb.Opacity = Math.Min(1 - GameService.Gw2Mumble.PlayerCamera.Forward.Y, 1f);
-            _eastBb.Opacity  = Math.Min(1 - GameService.Gw2Mumble.PlayerCamera.Forward.X, 1f);
-            _southBb.Opacity = Math.Min(1 + GameService.Gw2Mumble.PlayerCamera.Forward.Y, 1f);
-            _westBb.Opacity  = Math.Min(1 + GameService.Gw2Mumble.PlayerCamera.Forward.X, 1f);
+            if (_settingFadeForwardDirection.Value) {
+                _northBb.Opacity = Math.Min(1 - GameService.Gw2Mumble.PlayerCamera.Forward.Y, 1f);
+                _eastBb.Opacity  = Math.Min(1 - GameService.Gw2Mumble.PlayerCamera.Forward.X, 1f);
+                _southBb.Opacity = Math.Min(1 + GameService.Gw2Mumble.PlayerCamera.Forward.Y, 1f);
+                _westBb.Opacity  = Math.Min(1 + GameService.Gw2Mumble.PlayerCamera.Forward.X, 1f);
+            } else {
+                _northBb.Opacity = 1f;
+                _eastBb.Opacity  = 1f;
+                _southBb.Opacity = 1f;
+                _westBb.Opacity  = 1f;
+            }
         }
 
         /// <inheritdoc />

--- a/Compass Module/manifest.json
+++ b/Compass Module/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Compass",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "namespace": "bh.general.compass",
   "package": "Compass Module.dll",
   "manifest_version": 1,

--- a/Events Module/Events Module.csproj
+++ b/Events Module/Events Module.csproj
@@ -127,6 +127,11 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Gw2Sharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Gw2Sharp.1.7.0\lib\netstandard2.0\Gw2Sharp.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Humanizer, Version=2.6.0.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
       <HintPath>..\packages\Humanizer.Core.2.6.2\lib\netstandard2.0\Humanizer.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>

--- a/Events Module/EventsModule.cs
+++ b/Events Module/EventsModule.cs
@@ -182,7 +182,7 @@ namespace Events_Module {
                 eventPanel.FilterChildren<DetailsButton>(db => db.Text.ToLower().Contains(searchBox.Text.ToLower()));
             };
 
-            eventPanel.SuspendLayout();
+            //eventPanel.SuspendLayout();
 
             foreach (var meta in Meta.Events) {
                 var setting = _watchCollection.DefineSetting(@"watchEvent:" + meta.Name, true);
@@ -249,7 +249,7 @@ namespace Events_Module {
                     };
                 }
 
-                eventPanel.ResumeLayout();
+                //eventPanel.ResumeLayout(true);
 
                 var toggleFollowBttn = new GlowButton() {
                     Icon             = _textureWatch,

--- a/Events Module/Meta.cs
+++ b/Events Module/Meta.cs
@@ -179,11 +179,12 @@ namespace Events_Module {
                     uniqueEvents.Add(meta);
                 }
 
-                if (!string.IsNullOrEmpty(meta._wikiEn)) {
-                    var pageEn = new Uri(meta._wikiEn).Segments.Last();
-                    var task = GetInterwikiLinks(pageEn).ContinueWith(async v => meta._wikiLinks = await v);
-                    wikiTasks.Add(task);
-                }
+                // TODO: Disabled - blocked by wiki and we should likely prequery this info and host it statically somewhere.
+                //if (!string.IsNullOrEmpty(meta._wikiEn)) {
+                //    var pageEn = new Uri(meta._wikiEn).Segments.Last();
+                //    var task = GetInterwikiLinks(pageEn).ContinueWith(async v => meta._wikiLinks = await v);
+                //    wikiTasks.Add(task);
+                //}
             }
 
             await Task.WhenAll(wikiTasks.ToArray());
@@ -209,7 +210,7 @@ namespace Events_Module {
                           formatversion = 2,
                           llprop = "url"
                       });
-            var json = await url.GetJsonAsync();
+            var json = await url.WithHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.114 Safari/537.36 Edg/103.0.1264.49").GetJsonAsync();
             var wikiPage = json.query.pages[0];
             if (((IDictionary<string, object>)wikiPage).ContainsKey("langlinks")) {
                 var links = new Dictionary<string, string>();

--- a/Events Module/NotificationMover.cs
+++ b/Events Module/NotificationMover.cs
@@ -7,7 +7,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Events_Module {
-    public class NotificationMover : Control, IWindow {
+    public class NotificationMover : Control {
 
         // This is all very kludgy.  I wouldn't use it as a reference for anything.
 
@@ -26,8 +26,6 @@ namespace Events_Module {
         public NotificationMover(params ScreenRegion[] screenPositions) : this(screenPositions.ToList()) { /* NOOP */ }
 
         public NotificationMover(IEnumerable<ScreenRegion> screenPositions) {
-            WindowBase2.RegisterWindow(this);
-
             this.ZIndex = int.MaxValue - 10;
 
             _clearDrawParameters = new SpriteBatchParameters(SpriteSortMode.Deferred, BlendState.Opaque);
@@ -43,6 +41,14 @@ namespace Events_Module {
             }
 
             _grabPosition = this.RelativeMousePosition;
+        }
+
+        public override void DoUpdate(GameTime gameTime) {
+            base.DoUpdate(gameTime);
+
+            if (GameService.Input.Keyboard.KeysDown.Contains(Microsoft.Xna.Framework.Input.Keys.Escape)) {
+                this.Dispose();
+            }
         }
 
         protected override void OnLeftMouseButtonReleased(MouseEventArgs e) {
@@ -100,20 +106,6 @@ namespace Events_Module {
             }
 
             spriteBatch.DrawStringOnCtrl(this, "Press ESC to close.", GameService.Content.DefaultFont32, bounds, Color.White, false, HorizontalAlignment.Center);
-        }
-
-        public override void Hide() {
-            this.Dispose();
-        }
-
-        public void BringWindowToFront() { /* NOOP */ }
-
-        public bool   TopMost         => true;
-        public double LastInteraction { get; }
-        public bool   CanClose        => true;
-
-        protected override void DisposeControl() {
-            WindowBase2.UnregisterWindow(this);
         }
 
     }

--- a/Events Module/app.config
+++ b/Events Module/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/Events Module/manifest.json
+++ b/Events Module/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Events and Metas Observer",
-  "version": "0.9.2",
+  "version": "1.0.0",
   "namespace": "bh.general.events",
   "package": "Events Module.dll",
   "manifest_version": 1,

--- a/Events Module/packages.config
+++ b/Events Module/packages.config
@@ -9,7 +9,7 @@
   <package id="Gapotchenko.FX" version="2021.1.5" targetFramework="net472" />
   <package id="Gapotchenko.FX.Diagnostics.Process" version="2021.1.5" targetFramework="net472" />
   <package id="Gapotchenko.FX.Threading" version="2021.1.5" targetFramework="net472" />
-  <package id="Gw2Sharp" version="1.3.0" targetFramework="net472" />
+  <package id="Gw2Sharp" version="1.7.0" targetFramework="net472" />
   <package id="Humanizer.Core" version="2.6.2" targetFramework="net472" />
   <package id="Humanizer.Core.de" version="2.6.2" targetFramework="net472" />
   <package id="Humanizer.Core.es" version="2.6.2" targetFramework="net472" />


### PR DESCRIPTION
- Fixed a compatibility issue with the events module which prevented it from working in v0.11.8+ of Blish HUD.
- Fixed a bug with the events module where the control mover could not be closed if ESC to close windows was disabled in Blish HUD's settings.
- Added support for disabling reduced opacity in the compass module.