### PR TITLE
Add event timer for Convergences instance event

### DIFF
--- a/Events Module/manifest.json
+++ b/Events Module/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Events and Metas Observer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "namespace": "bh.general.events",
   "package": "Events Module.dll",
   "manifest_version": 1,

--- a/Events Module/ref/events.json
+++ b/Events Module/ref/events.json
@@ -1109,5 +1109,18 @@
     "duration": "25",
     "alert": 10,
     "icon": "0339A231A4973455D69AD7DCF222F50C1148206E/3124847"
+  },
+  {
+    "name": "Convergences (Public)",
+    "offset": "01:30Z",
+    "repeat": "03:00",
+    "difficulty": "",
+    "category": "The Wizard's Tower",
+    "location": "The Wizard's Tower",
+    "waypoint": "[&BB8OAAA=]",
+    "wiki": "https://wiki.guildwars2.com/wiki/Convergences",
+    "duration": "10",
+    "alert": 10,
+    "icon": "49B0902552EFD9E9A0A11C027CA3BBE3507C266B/3124849"
   }
 ]


### PR DESCRIPTION
* Added new `Convergences (Public)` event https://wiki.guildwars2.com/wiki/Convergences
* Bump manifest.json version

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

Not a new feature

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
