### PR TITLE
Added Moredremoth's Minions cyclical events to EMO

### DIFF
--- a/Events Module/ref/events.json
+++ b/Events Module/ref/events.json
@@ -531,6 +531,45 @@
     "icon": "57490B059669DA64517C99BCA5A359082696DEC9/638120"
   },
   {
+    "name": "Moredremoth Invasion: Brisban Wildlands",
+    "offset": "00:30Z",
+    "repeat": "04:00",
+    "difficulty": "",
+    "category": "Group Event",
+    "location": "Brisban Wildlands",
+    "waypoint": "&BFwAAAA=]",
+    "wiki": "https://wiki.guildwars2.com/wiki/Mordremoth%27s_Minions_Invade_Tyria",
+    "alert": 15,
+    "duration": "15",
+    "icon": "91EA7224450CBD98C62544ECFDDD231DDA3A7E0E/1302680"
+  },
+  {
+    "name": "Moredremoth Invasion: Kessex Hils",
+    "offset": "01:30Z",
+    "repeat": "04:00",
+    "difficulty": "",
+    "category": "Group Event",
+    "location": "Kessex Hils",
+    "waypoint": "[&BAoAAAA=]",
+    "wiki": "https://wiki.guildwars2.com/wiki/Mordremoth%27s_Minions_Invade_Tyria",
+    "alert": 15,
+    "duration": "15",
+    "icon": "91EA7224450CBD98C62544ECFDDD231DDA3A7E0E/1302680"
+  },
+  {
+    "name": "Moredremoth Invasion: Diessa Plateau",
+    "offset": "02:30Z",
+    "repeat": "04:00",
+    "difficulty": "",
+    "category": "Group Event",
+    "location": "Diessa Plateau",
+    "waypoint": "[&BNkAAAA=]",
+    "wiki": "https://wiki.guildwars2.com/wiki/Mordremoth%27s_Minions_Invade_Tyria",
+    "alert": 15,
+    "duration": "15",
+    "icon": "91EA7224450CBD98C62544ECFDDD231DDA3A7E0E/1302680"
+  },
+  {
     "name": "Crash Site",
     "offset": "00:00Z",
     "repeat": "01:00",


### PR DESCRIPTION
## Discussion Reference
Deleted suggestion channel for adding https://wiki.guildwars2.com/wiki/Mordremoth's_Minions_Invade_Tyria to EMO. https://discord.com/channels/531175899588984842/534490472224391169/1406395169871237141

## Is this a breaking change?
No
